### PR TITLE
docs: fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@
 
 * Supported formats:  CBZ, CBR, CBT, CB7, and PDF
 * Optimizes pages to improve read times on-the-fly
-* Efficent CRUD, filtering, sorting
+* Efficient CRUD, filtering, sorting
   *  Intelligently pre-fetches pages, so you're *never* waiting on it to send you the next page
 * APIs / Services
   * JSON:API

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,4 +8,4 @@
 
 ## Reporting a Vulnerability
 
-Please report any vulernability to cam.cook.codes AT gmail.com
+Please report any vulnerability to cam.cook.codes AT gmail.com


### PR DESCRIPTION
Found via `codespell -S deps -L bu,statics`